### PR TITLE
Specify Hashie version required (2.x)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     avalara (0.0.3)
-      hashie
+      hashie (~> 2)
       httparty
       multi_json
 

--- a/avalara.gemspec
+++ b/avalara.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'hashie'
+  s.add_dependency 'hashie', '~> 2'
   s.add_dependency 'httparty'
   s.add_dependency 'multi_json'
 


### PR DESCRIPTION
Hashie 2.x features (`Hashie::Extensions::Coercion`) are used by the Avalara gem, but this particular version is not specified as a dependency.